### PR TITLE
Implement `cancel_at` column in `users` table

### DIFF
--- a/bloggies_backend/src/data.sql
+++ b/bloggies_backend/src/data.sql
@@ -26,7 +26,8 @@ CREATE TABLE users (
   membership_end_date TIMESTAMP WITH TIME ZONE,
   last_submission_date TIMESTAMP WITH TIME ZONE,
   customer_id TEXT,
-  subscription_id TEXT
+  subscription_id TEXT,
+  cancel_at TIMESTAMP WITH TIME ZONE, 
 );
 
 CREATE TABLE posts (
@@ -75,7 +76,7 @@ VALUES
 
 INSERT INTO users(user_id, display_name, membership_status, membership_start_date, membership_end_date) 
 VALUES 
-    (3, 'StrawberryBasilFan', 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + interval '30 days');
+    (3, 'StrawberryBasilFan', 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + interval '30 days', CURRENT_TIMESTAMP + interval '7 days');
 
 INSERT INTO posts(title, description, body, author_id, is_premium)
 VALUES

--- a/bloggies_backend/src/data.sql
+++ b/bloggies_backend/src/data.sql
@@ -27,7 +27,7 @@ CREATE TABLE users (
   last_submission_date TIMESTAMP WITH TIME ZONE,
   customer_id TEXT,
   subscription_id TEXT,
-  cancel_at TIMESTAMP WITH TIME ZONE, 
+  cancel_at TIMESTAMP WITH TIME ZONE
 );
 
 CREATE TABLE posts (
@@ -74,7 +74,7 @@ VALUES
     (2, 'testuser', 'pending');
 
 
-INSERT INTO users(user_id, display_name, membership_status, membership_start_date, membership_end_date) 
+INSERT INTO users(user_id, display_name, membership_status, membership_start_date, membership_end_date, cancel_at) 
 VALUES 
     (3, 'StrawberryBasilFan', 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + interval '30 days', CURRENT_TIMESTAMP + interval '7 days');
 


### PR DESCRIPTION
`cancel_at` column added to keep track of the subscription cancellation, if the weekly contribution requirement is not met. 

# Backend Changes 
- Update the `data.sql` file to include `cancel_at` (timestamp with timezone) in the `users` table. 
      -  The insert statement for `StrawberryBasilFan` has been updated to include a `cancel_at` column value.
