### PR TITLE
Fix for the filtering drop down selections not changing their display string

### DIFF
--- a/bloggies_frontend/src/BlogFilter/index.tsx
+++ b/bloggies_frontend/src/BlogFilter/index.tsx
@@ -1,15 +1,20 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Dropdown } from "react-bootstrap";
 import { Post } from "../custom";
 
 interface IProp {
   posts: Post[];
   handlePostFilter: Function;
+  currentSort: string
 }
 
-function BlogFilter({ posts, handlePostFilter }: IProp) {
+function BlogFilter({ posts, handlePostFilter, currentSort }: IProp) {
   const DEFAULT_FILTER_SELECT = "all";
   const [ filterType, setfilterType ] = useState<string>(DEFAULT_FILTER_SELECT);
+
+  useEffect(() => {
+    handleSelection(currentSort);
+  }, [posts]);
 
   const handleSelection = (eventKey: string | null) => {
     let filteredPosts: Post[] = [];

--- a/bloggies_frontend/src/RoutedPages/BlogPage/index.tsx
+++ b/bloggies_frontend/src/RoutedPages/BlogPage/index.tsx
@@ -16,7 +16,8 @@ function BlogPage() {
   const currentUser = useSelector((st: CustomReduxState) => st.user);
   const dispatch = useDispatch();
   const [posts, setPosts] = useState<Array<Post>>([]);
-  const [sortType, setSortType] = useState("mostRecent")
+  const [sortType, setSortType] = useState("mostRecent");
+  const [postFilterType, setPostFilterType] = useState("all");
 
   useEffect(function handleLoadPosts() {
     // Fetch for updated membership status if logged in (FE handles UI theme btwn un/paid)
@@ -30,9 +31,13 @@ function BlogPage() {
   }, []);
 
   // invoked in `SortSelection` component when a user chooses a sort type in the dropdown.
-  const handlePostSort = (sortedPosts: Array<Post>, newSortType: string) => {
+  const handleBookmarkFilter = (sortedPosts: Array<Post>, newSortType: string) => {
     setPosts(sortedPosts);
     setSortType(newSortType);
+
+    if (postFilterType !== "all") {
+      setPostFilterType("all");
+    };
   }
 
   const handlePostFilter = (filteredPosts: Array<Post>, newFilterType: string) => {
@@ -40,6 +45,11 @@ function BlogPage() {
       setPosts(filteredPosts);
     } else {
       setPosts(postsList);
+    }
+    setPostFilterType(newFilterType);
+
+    if (sortType !== "mostRecent") {
+      setSortType("mostRecent");
     }
   }
 
@@ -51,10 +61,10 @@ function BlogPage() {
             <h1 className="text-left">Bloggies newsfeed</h1>
           </Col>
           <Col md={3}>
-            <SortSelection handlePostSort={handlePostSort} posts={postsList} currentSort={sortType} />
+            <SortSelection key={sortType} handlePostSort={handleBookmarkFilter} posts={postsList} currentSort={sortType} />
           </Col>
           <Col md={3}>
-            {currentUser.membership_status === "active" && <BlogFilter posts={postsList} handlePostFilter={handlePostFilter} />}
+            {currentUser.membership_status === "active" && <BlogFilter key={postFilterType} posts={postsList} handlePostFilter={handlePostFilter} currentSort={postFilterType}/>}
           </Col>
         </Row>
         <BlogList key={sortType} posts={posts} />

--- a/bloggies_frontend/src/redux/rootReducer.tsx
+++ b/bloggies_frontend/src/redux/rootReducer.tsx
@@ -31,7 +31,6 @@ function rootReducer(state = INITIAL_STATE, action: Action) {
       const updateAddFavPosts = state.posts.map((p: Post) => {
         // Increment the favorite count of the post
         if (p.id === action.payload.post.id) {
-          // POST-SUBMISSION UPDATE: adding a "currentValue variable".
           let currentValue = parseInt(p.bookmark_count) || 0;
           const newFavCount = currentValue + 1;
           p.bookmark_count = newFavCount.toString();


### PR DESCRIPTION
When filtering by Premium posts and user bookmarks a post, the filtering disappears and shows all the posts regardless of previous filter.

To fix this, I made sure the selection drop down will revert to the default behavior ("**most recent**" and "**all**" posts)

### Frontend changes
- Add a `key` prop to `BlogFilter` and `SortSelection` to ensure that the `currentSort` displayed will be accurate to how the blog filtering happens. 
- Add a useEffect in `BlogFilter` component


