### PR TITLE
Cancel immediately

### DIFF
--- a/bloggies_backend/src/models/email.ts
+++ b/bloggies_backend/src/models/email.ts
@@ -130,8 +130,8 @@ export default class Email {
             from: verifiedSender,
             templateId: 'd-3aa8b6c7059c49999b592116bf95cd7a', //Warning Template
             dynamicTemplateData: {
-                subject: 'Your Learning Circle Membership has Expired',
-                body: 'Your membership has expired either because you did not pay your monthly fee, or because you did not meet the submission criteria. We hate to see you go, but please sign up again if you would like to rejoin!',
+                subject: 'Your Learning Circle Membership has been cancelled',
+                body: 'Your membership has been cancelled either because you canclled it, you did not pay your monthly fee, or because you did not meet the submission criteria. We hate to see you go, but please sign up again if you would like to rejoin!',
                 buttonUrl: FRONTEND_URL
             }
         }

--- a/bloggies_backend/src/routes/stripe.ts
+++ b/bloggies_backend/src/routes/stripe.ts
@@ -74,8 +74,6 @@ stripeRouter.post("/webhook", async function (req: Request, res: Response, next:
         console.log("subscription deleted");
         data = event.data.object;
         await User.cancelSubscription(data.id, data.current_period_end);
-        const userInfo = await User.getUserBySubscriptionId(data.id);
-        await Email.sendExpiredNotification(userInfo.email);
         break;
       case 'customer.subscription.created':
         data = event.data.object;
@@ -197,6 +195,10 @@ stripeRouter.delete(
       const cancelledSubscription = await Checkout.stripeSubscriptionCancel(
         req.body.subscription_id
       );
+      console.log(cancelledSubscription);
+      await User.cancelSubscription(cancelledSubscription.id, cancelledSubscription.current_period_end);
+        const userInfo = await User.getUserBySubscriptionId(cancelledSubscription.id);
+        await Email.sendExpiredNotification(userInfo.email);
       res.send({ cancelled_subscription: cancelledSubscription });
     } catch (err) {
       return next(err);

--- a/bloggies_backend/src/routes/stripe.ts
+++ b/bloggies_backend/src/routes/stripe.ts
@@ -195,8 +195,7 @@ stripeRouter.delete(
       const cancelledSubscription = await Checkout.stripeSubscriptionCancel(
         req.body.subscription_id
       );
-      console.log(cancelledSubscription);
-      await User.cancelSubscription(cancelledSubscription.id, cancelledSubscription.current_period_end);
+        await User.cancelSubscription(cancelledSubscription.id, cancelledSubscription.current_period_end);
         const userInfo = await User.getUserBySubscriptionId(cancelledSubscription.id);
         await Email.sendExpiredNotification(userInfo.email);
       res.send({ cancelled_subscription: cancelledSubscription });

--- a/bloggies_backend/src/routes/userAuths.ts
+++ b/bloggies_backend/src/routes/userAuths.ts
@@ -3,6 +3,7 @@ import ExpressError from "../expressError";
 import UserAuth from "../models/userAuth";
 import User from "../models/user";
 import Checkout from "../models/stripe";
+import { ACTIVE } from "../membershipStatuses";
 
 export const userAuthRouter = express.Router();
 
@@ -47,7 +48,7 @@ userAuthRouter.post("/login", async function (req: Request, res: Response, next:
     res.cookie("token", authResult.token);
 
     const now = new Date();
-    const isOverdue = user.cancel_at ? now >= user.cancel_at : false;
+    const isOverdue = user.membership_status === ACTIVE && user.cancel_at ? now >= user.cancel_at : false;
 
     if(isOverdue) {
       try{


### PR DESCRIPTION
- Adds logic to the cancel subscription endpoint to update our database without waiting for the webhook.
- Email will be sent from there instead of from the webhook event.

